### PR TITLE
Add "unsafe-eval" to script-src CSP

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -31,7 +31,7 @@ if Rails.env.production?
     p.base_uri        :none
     p.default_src     :none
     p.frame_ancestors :none
-    p.script_src      :self, assets_host
+    p.script_src      :self, assets_host, :unsafe_eval
     p.font_src        :self, assets_host
     p.img_src         :self, :data, :blob, *data_hosts
     p.style_src       :self, assets_host


### PR DESCRIPTION
> Firefox now supports Content-Security-Policy (CSP) integration with WebAssembly. A document with a CSP that restricts scripts will no longer execute WebAssembly unless the policy uses 'unsafe-eval' or the new 'wasm-unsafe-eval' keyword."

https://connect.mozilla.org/t5/discussions/new-csp-enhancements-in-firefox-102/td-p/8816

See also:
- mastodon/mastodon#18750
- mastodon/mastodon#18817
- glitch-soc/mastodon#1806