### PR TITLE
Revert "Add link to status page"

### DIFF
--- a/app/javascript/flavours/glitch/features/ui/components/link_footer.js
+++ b/app/javascript/flavours/glitch/features/ui/components/link_footer.js
@@ -79,8 +79,6 @@ class LinkFooter extends React.PureComponent {
           )}
           {DividingCircle}
           <Link key='privacy-policy' to='/privacy-policy'><FormattedMessage id='footer.privacy_policy' defaultMessage='Privacy policy' /></Link>
-          {' · '}
-          <a key='cit-status' href='https://status.compostintraining.club' target='_blank'><FormattedMessage id='footer.status' defaultMessage='Status' /></a>
         </p>
 
         <p>


### PR DESCRIPTION
Reverts CompostInTraining/mastodon#70

Mastodon now supports status page links first class. (mastodon#23390, mastodon#23499)